### PR TITLE
(multi trie management) perf: make binary nodes compute their edges in parallel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ derive_more = { version = "0.99.17", default-features = false, features = [
 hashbrown = "0.14.3"
 log = "0.4.20"
 smallvec = "1.11.2"
+rayon = "1.9.0"
 
 parity-scale-codec = { version = "3.0.0", default-features = false, features = [
     "derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,8 @@ version = "0.1.0"
 default = ["std", "rocksdb"]
 rocksdb = ["dep:rocksdb"]
 std = ["parity-scale-codec/std", "bitvec/std", "starknet-types-core/std"]
+# internal
+bench = []
 
 [dependencies]
 bitvec = { version = "1", default-features = false, features = ["alloc"] }
@@ -48,4 +50,5 @@ criterion = "0.5.1"
 
 [[bench]]
 name = "storage"
+required-features = ["bench"]
 harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ serde = { version = "1.0.195", default-features = false, features = [
     "derive",
     "alloc",
 ] }
-starknet-types-core = { version = "0.0.7", default-features = false, features = [
+starknet-types-core = { version = "0.0.11", default-features = false, features = [
     "hash",
     "parity-scale-codec",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ rocksdb = { optional = true, version = "0.21.0", features = [
 ] }
 
 [dev-dependencies]
+pprof = { version = "0.3", features = ["flamegraph"] }
 pathfinder-common = { git = "https://github.com/massalabs/pathfinder.git", package = "pathfinder-common", rev = "b7b6d76a76ab0e10f92e5f84ce099b5f727cb4db" }
 pathfinder-crypto = { git = "https://github.com/massalabs/pathfinder.git", package = "pathfinder-crypto", rev = "b7b6d76a76ab0e10f92e5f84ce099b5f727cb4db" }
 pathfinder-merkle-tree = { git = "https://github.com/massalabs/pathfinder.git", package = "pathfinder-merkle-tree", rev = "b7b6d76a76ab0e10f92e5f84ce099b5f727cb4db" }
@@ -43,3 +44,8 @@ pathfinder-storage = { git = "https://github.com/massalabs/pathfinder.git", pack
 rand = "0.8.5"
 tempfile = "3.8.0"
 rstest = "0.18.2"
+criterion = "0.5.1"
+
+[[bench]]
+name = "storage"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ serde = { version = "1.0.195", default-features = false, features = [
     "derive",
     "alloc",
 ] }
-starknet-types-core = { version = "0.0.11", default-features = false, features = [
+starknet-types-core = { git = "https://github.com/starknet-io/types-rs", branch = "main", default-features = false, features = [
     "hash",
     "parity-scale-codec",
 ] }

--- a/benches/flamegraph.rs
+++ b/benches/flamegraph.rs
@@ -1,0 +1,39 @@
+use criterion::profiler::Profiler;
+use pprof::ProfilerGuard;
+use std::{fs::File, os::raw::c_int, path::Path};
+
+pub struct FlamegraphProfiler<'a> {
+    frequency: c_int,
+    active_profiler: Option<ProfilerGuard<'a>>,
+}
+
+impl<'a> FlamegraphProfiler<'a> {
+    #[allow(dead_code)]
+    pub fn new(frequency: c_int) -> Self {
+        FlamegraphProfiler {
+            frequency,
+            active_profiler: None,
+        }
+    }
+}
+
+impl<'a> Profiler for FlamegraphProfiler<'a> {
+    fn start_profiling(&mut self, _benchmark_id: &str, _benchmark_dir: &Path) {
+        self.active_profiler = Some(ProfilerGuard::new(self.frequency).unwrap());
+    }
+
+    fn stop_profiling(&mut self, _benchmark_id: &str, benchmark_dir: &Path) {
+        std::fs::create_dir_all(benchmark_dir).unwrap();
+        let flamegraph_path = benchmark_dir.join("flamegraph.svg");
+        let flamegraph_file = File::create(&flamegraph_path)
+            .expect("File system error while creating flamegraph.svg");
+        if let Some(profiler) = self.active_profiler.take() {
+            profiler
+                .report()
+                .build()
+                .unwrap()
+                .flamegraph(flamegraph_file)
+                .expect("Error writing flamegraph");
+        }
+    }
+}

--- a/benches/storage.rs
+++ b/benches/storage.rs
@@ -1,0 +1,147 @@
+use std::hint::black_box;
+
+use bitvec::vec::BitVec;
+use bonsai_trie::{
+    databases::HashMapDb,
+    id::{BasicId, BasicIdBuilder},
+    BonsaiStorage, BonsaiStorageConfig,
+};
+use criterion::{criterion_group, criterion_main, Criterion};
+use rand::{prelude::*, thread_rng};
+use starknet_types_core::{
+    felt::Felt,
+    hash::{Pedersen, StarkHash},
+};
+
+mod flamegraph;
+
+fn storage(c: &mut Criterion) {
+    c.bench_function("storage commit", move |b| {
+        let mut bonsai_storage: BonsaiStorage<BasicId, _, Pedersen> = BonsaiStorage::new(
+            HashMapDb::<BasicId>::default(),
+            BonsaiStorageConfig::default(),
+        )
+        .unwrap();
+        let mut rng = thread_rng();
+
+        let felt = Felt::from_hex("0x66342762FDD54D033c195fec3ce2568b62052e").unwrap();
+        for _ in 0..1000 {
+            let bitvec = BitVec::from_vec(vec![
+                rng.gen(),
+                rng.gen(),
+                rng.gen(),
+                rng.gen(),
+                rng.gen(),
+                rng.gen(),
+            ]);
+            bonsai_storage.insert(&[], &bitvec, &felt).unwrap();
+        }
+
+        let mut id_builder = BasicIdBuilder::new();
+        b.iter_batched(
+            || bonsai_storage.clone(),
+            |mut bonsai_storage| {
+                bonsai_storage.commit(id_builder.new_id()).unwrap();
+            },
+            criterion::BatchSize::LargeInput,
+        );
+    });
+}
+
+fn one_update(c: &mut Criterion) {
+    c.bench_function("one update", move |b| {
+        let mut bonsai_storage: BonsaiStorage<BasicId, _, Pedersen> = BonsaiStorage::new(
+            HashMapDb::<BasicId>::default(),
+            BonsaiStorageConfig::default(),
+        )
+        .unwrap();
+        let mut rng = thread_rng();
+
+        let felt = Felt::from_hex("0x66342762FDD54D033c195fec3ce2568b62052e").unwrap();
+        for _ in 0..1000 {
+            let bitvec = BitVec::from_vec(vec![
+                rng.gen(),
+                rng.gen(),
+                rng.gen(),
+                rng.gen(),
+                rng.gen(),
+                rng.gen(),
+            ]);
+            bonsai_storage.insert(&[], &bitvec, &felt).unwrap();
+        }
+
+        let mut id_builder = BasicIdBuilder::new();
+        bonsai_storage.commit(id_builder.new_id()).unwrap();
+
+        b.iter_batched(
+            || bonsai_storage.clone(),
+            |mut bonsai_storage| {
+                let bitvec = BitVec::from_vec(vec![0, 1, 2, 3, 4, 5]);
+                bonsai_storage.insert(&[], &bitvec, &felt).unwrap();
+                bonsai_storage.commit(id_builder.new_id()).unwrap();
+            },
+            criterion::BatchSize::LargeInput,
+        );
+    });
+}
+
+fn five_updates(c: &mut Criterion) {
+    c.bench_function("five updates", move |b| {
+        let mut bonsai_storage: BonsaiStorage<BasicId, _, Pedersen> = BonsaiStorage::new(
+            HashMapDb::<BasicId>::default(),
+            BonsaiStorageConfig::default(),
+        )
+        .unwrap();
+        let mut rng = thread_rng();
+
+        let felt = Felt::from_hex("0x66342762FDD54D033c195fec3ce2568b62052e").unwrap();
+        for _ in 0..1000 {
+            let bitvec = BitVec::from_vec(vec![
+                rng.gen(),
+                rng.gen(),
+                rng.gen(),
+                rng.gen(),
+                rng.gen(),
+                rng.gen(),
+            ]);
+            bonsai_storage.insert(&[], &bitvec, &felt).unwrap();
+        }
+
+        let mut id_builder = BasicIdBuilder::new();
+        bonsai_storage.commit(id_builder.new_id()).unwrap();
+
+        b.iter_batched(
+            || bonsai_storage.clone(),
+            |mut bonsai_storage| {
+                bonsai_storage.insert(&[], &BitVec::from_vec(vec![0, 1, 2, 3, 4, 5]), &felt).unwrap();
+                bonsai_storage.insert(&[], &BitVec::from_vec(vec![0, 2, 2, 5, 4, 5]), &felt).unwrap();
+                bonsai_storage.insert(&[], &BitVec::from_vec(vec![0, 1, 2, 3, 3, 5]), &felt).unwrap();
+                bonsai_storage.insert(&[], &BitVec::from_vec(vec![0, 1, 1, 3, 99, 3]), &felt).unwrap();
+                bonsai_storage.insert(&[], &BitVec::from_vec(vec![0, 1, 2, 3, 4, 6]), &felt).unwrap();
+                bonsai_storage.commit(id_builder.new_id()).unwrap();
+            },
+            criterion::BatchSize::LargeInput,
+        );
+    });
+}
+
+fn hash(c: &mut Criterion) {
+    c.bench_function("pedersen hash", move |b| {
+        let felt0 =
+            Felt::from_hex("0x100bd6fbfced88ded1b34bd1a55b747ce3a9fde9a914bca75571e4496b56443")
+                .unwrap();
+        let felt1 =
+            Felt::from_hex("0x00a038cda302fedbc4f6117648c6d3faca3cda924cb9c517b46232c6316b152f")
+                .unwrap();
+        b.iter(|| {
+            black_box(Pedersen::hash(&felt0, &felt1));
+        })
+    });
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default(); // .with_profiler(flamegraph::FlamegraphProfiler::new(100));
+    targets = storage, one_update, five_updates, hash
+}
+criterion_main!(benches);

--- a/benches/storage.rs
+++ b/benches/storage.rs
@@ -113,11 +113,21 @@ fn five_updates(c: &mut Criterion) {
         b.iter_batched(
             || bonsai_storage.clone(),
             |mut bonsai_storage| {
-                bonsai_storage.insert(&[], &BitVec::from_vec(vec![0, 1, 2, 3, 4, 5]), &felt).unwrap();
-                bonsai_storage.insert(&[], &BitVec::from_vec(vec![0, 2, 2, 5, 4, 5]), &felt).unwrap();
-                bonsai_storage.insert(&[], &BitVec::from_vec(vec![0, 1, 2, 3, 3, 5]), &felt).unwrap();
-                bonsai_storage.insert(&[], &BitVec::from_vec(vec![0, 1, 1, 3, 99, 3]), &felt).unwrap();
-                bonsai_storage.insert(&[], &BitVec::from_vec(vec![0, 1, 2, 3, 4, 6]), &felt).unwrap();
+                bonsai_storage
+                    .insert(&[], &BitVec::from_vec(vec![0, 1, 2, 3, 4, 5]), &felt)
+                    .unwrap();
+                bonsai_storage
+                    .insert(&[], &BitVec::from_vec(vec![0, 2, 2, 5, 4, 5]), &felt)
+                    .unwrap();
+                bonsai_storage
+                    .insert(&[], &BitVec::from_vec(vec![0, 1, 2, 3, 3, 5]), &felt)
+                    .unwrap();
+                bonsai_storage
+                    .insert(&[], &BitVec::from_vec(vec![0, 1, 1, 3, 99, 3]), &felt)
+                    .unwrap();
+                bonsai_storage
+                    .insert(&[], &BitVec::from_vec(vec![0, 1, 2, 3, 4, 6]), &felt)
+                    .unwrap();
                 bonsai_storage.commit(id_builder.new_id()).unwrap();
             },
             criterion::BatchSize::LargeInput,

--- a/ensure_no_std/Cargo.lock
+++ b/ensure_no_std/Cargo.lock
@@ -62,6 +62,7 @@ dependencies = [
  "hashbrown",
  "log",
  "parity-scale-codec",
+ "rayon",
  "serde",
  "smallvec",
  "starknet-types-core",
@@ -95,6 +96,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,6 +150,12 @@ dependencies = [
  "block-buffer",
  "crypto-common",
 ]
+
+[[package]]
+name = "either"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
 name = "ensure_no_std"
@@ -338,6 +370,26 @@ name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "serde"

--- a/src/changes.rs
+++ b/src/changes.rs
@@ -15,7 +15,7 @@ pub struct Change {
 }
 
 #[derive(Debug, Default)]
-#[derive(Clone)]
+#[cfg_attr(feature = "bench", derive(Clone))]
 pub struct ChangeBatch(pub(crate) HashMap<TrieKey, Change>);
 
 const KEY_SEPARATOR: u8 = 0x00;
@@ -116,7 +116,7 @@ impl ChangeBatch {
     }
 }
 
-#[derive(Clone)]
+#[cfg_attr(feature = "bench", derive(Clone))]
 pub struct ChangeStore<ID>
 where
     ID: Id,

--- a/src/changes.rs
+++ b/src/changes.rs
@@ -15,6 +15,7 @@ pub struct Change {
 }
 
 #[derive(Debug, Default)]
+#[derive(Clone)]
 pub struct ChangeBatch(pub(crate) HashMap<TrieKey, Change>);
 
 const KEY_SEPARATOR: u8 = 0x00;
@@ -115,6 +116,7 @@ impl ChangeBatch {
     }
 }
 
+#[derive(Clone)]
 pub struct ChangeStore<ID>
 where
     ID: Id,

--- a/src/id.rs
+++ b/src/id.rs
@@ -11,6 +11,12 @@ pub trait Id: hash::Hash + PartialEq + Eq + PartialOrd + Ord + Debug + Copy + De
 #[derive(Hash, PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Copy, Default)]
 pub struct BasicId(u64);
 
+impl BasicId {
+    pub fn new(id: u64) -> Self {
+        BasicId(id)
+    }
+}
+
 impl Id for BasicId {
     fn to_bytes(&self) -> Vec<u8> {
         self.0.to_be_bytes().to_vec()

--- a/src/key_value_db.rs
+++ b/src/key_value_db.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 
 /// Crate Trie <= KeyValueDB => BonsaiDatabase
-#[derive(Clone)]
+#[cfg_attr(feature = "bench", derive(Clone))]
 pub struct KeyValueDB<DB, ID>
 where
     DB: BonsaiDatabase,

--- a/src/key_value_db.rs
+++ b/src/key_value_db.rs
@@ -18,6 +18,7 @@ use crate::{
 };
 
 /// Crate Trie <= KeyValueDB => BonsaiDatabase
+#[derive(Clone)]
 pub struct KeyValueDB<DB, ID>
 where
     DB: BonsaiDatabase,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,41 +16,42 @@
 //! let db = create_rocks_db("./rocksdb").unwrap();
 //! let config = BonsaiStorageConfig::default();
 //!
+//! let identifier = vec![];
 //! let mut bonsai_storage: BonsaiStorage<_, _, Pedersen> = BonsaiStorage::new(RocksDB::new(&db, RocksDBConfig::default()), config).unwrap();
 //! let mut id_builder = BasicIdBuilder::new();
 //!
 //! let pair1 = (vec![1, 2, 1], Felt::from_hex("0x66342762FDD54D033c195fec3ce2568b62052e").unwrap());
 //! let bitvec_1 = BitVec::from_vec(pair1.0.clone());
-//! bonsai_storage.insert(&bitvec_1, &pair1.1).unwrap();
+//! bonsai_storage.insert(&identifier, &bitvec_1, &pair1.1).unwrap();
 //!
 //! let pair2 = (vec![1, 2, 2], Felt::from_hex("0x66342762FD54D033c195fec3ce2568b62052e").unwrap());
 //! let bitvec = BitVec::from_vec(pair2.0.clone());
-//! bonsai_storage.insert(&bitvec, &pair2.1).unwrap();
+//! bonsai_storage.insert(&identifier, &bitvec, &pair2.1).unwrap();
 //!
 //! let id1 = id_builder.new_id();
 //! bonsai_storage.commit(id1);
 //!
 //! let pair3 = (vec![1, 2, 2], Felt::from_hex("0x664D033c195fec3ce2568b62052e").unwrap());
 //! let bitvec = BitVec::from_vec(pair3.0.clone());
-//! bonsai_storage.insert(&bitvec, &pair3.1).unwrap();
+//! bonsai_storage.insert(&identifier, &bitvec, &pair3.1).unwrap();
 //!
 //! let revert_to_id = id_builder.new_id();
 //! bonsai_storage.commit(revert_to_id);
 //!
-//! bonsai_storage.remove(&bitvec).unwrap();
+//! bonsai_storage.remove(&identifier, &bitvec).unwrap();
 //!
 //! bonsai_storage.commit(id_builder.new_id());
 //!
-//! println!("root: {:#?}", bonsai_storage.root_hash());
+//! println!("root: {:#?}", bonsai_storage.root_hash(&identifier));
 //! println!(
 //!     "value: {:#?}",
-//!     bonsai_storage.get(&bitvec_1).unwrap()
+//!     bonsai_storage.get(&identifier, &bitvec_1).unwrap()
 //! );
 //!
 //! bonsai_storage.revert_to(revert_to_id).unwrap();
 //!
-//! println!("root: {:#?}", bonsai_storage.root_hash());
-//! println!("value: {:#?}", bonsai_storage.get(&bitvec).unwrap());
+//! println!("root: {:#?}", bonsai_storage.root_hash(&identifier));
+//! println!("value: {:#?}", bonsai_storage.get(&identifier, &bitvec).unwrap());
 //! std::thread::scope(|s| {
 //!     s.spawn(|| {
 //!         let bonsai_at_txn: BonsaiStorage<_, _, Pedersen> = bonsai_storage
@@ -58,7 +59,7 @@
 //!             .unwrap()
 //!             .unwrap();
 //!         let bitvec = BitVec::from_vec(pair1.0.clone());
-//!         assert_eq!(bonsai_at_txn.get(&bitvec).unwrap().unwrap(), pair1.1);
+//!         assert_eq!(bonsai_at_txn.get(&identifier, &bitvec).unwrap().unwrap(), pair1.1);
 //!     });
 //!
 //!     s.spawn(|| {
@@ -67,18 +68,18 @@
 //!             .unwrap()
 //!             .unwrap();
 //!         let bitvec = BitVec::from_vec(pair1.0.clone());
-//!         assert_eq!(bonsai_at_txn.get(&bitvec).unwrap().unwrap(), pair1.1);
+//!         assert_eq!(bonsai_at_txn.get(&identifier, &bitvec).unwrap().unwrap(), pair1.1);
 //!     });
 //! });
 //! bonsai_storage
-//!     .get(&BitVec::from_vec(vec![1, 2, 2]))
+//!     .get(&identifier, &BitVec::from_vec(vec![1, 2, 2]))
 //!     .unwrap();
 //! let pair2 = (
 //!     vec![1, 2, 3],
 //!     Felt::from_hex("0x66342762FDD54D033c195fec3ce2568b62052e").unwrap(),
 //! );
 //! bonsai_storage
-//!     .insert(&BitVec::from_vec(pair2.0.clone()), &pair2.1)
+//!     .insert(&identifier, &BitVec::from_vec(pair2.0.clone()), &pair2.1)
 //!     .unwrap();
 //! bonsai_storage.commit(id_builder.new_id()).unwrap();
 //! ```
@@ -111,6 +112,7 @@ pub mod id;
 
 pub use bonsai_database::{BonsaiDatabase, BonsaiPersistentDatabase, DBError, DatabaseKey};
 pub use error::BonsaiStorageError;
+use trie::merkle_tree::MerkleTrees;
 pub use trie::merkle_tree::{Membership, ProofNode};
 
 #[cfg(test)]
@@ -161,9 +163,9 @@ pub struct BonsaiStorage<ChangeID, DB, H>
 where
     DB: BonsaiDatabase,
     ChangeID: id::Id,
-    H: StarkHash,
+    H: StarkHash + Send + Sync,
 {
-    trie: MerkleTree<H, DB, ChangeID>,
+    tries: MerkleTrees<H, DB, ChangeID>,
 }
 
 /// Trie root hash type.
@@ -173,7 +175,7 @@ impl<ChangeID, DB, H> BonsaiStorage<ChangeID, DB, H>
 where
     DB: BonsaiDatabase,
     ChangeID: id::Id,
-    H: StarkHash,
+    H: StarkHash + Send + Sync,
 {
     /// Create a new bonsai storage instance
     pub fn new(
@@ -182,7 +184,7 @@ where
     ) -> Result<Self, BonsaiStorageError<DB::DatabaseError>> {
         let key_value_db = KeyValueDB::new(db, config.into(), None);
         Ok(Self {
-            trie: MerkleTree::new(key_value_db)?,
+            tries: MerkleTrees::new(key_value_db),
         })
     }
 
@@ -190,21 +192,36 @@ where
         db: DB,
         config: BonsaiStorageConfig,
         created_at: ChangeID,
+        identifiers: Vec<Vec<u8>>,
     ) -> Result<Self, BonsaiStorageError<DB::DatabaseError>> {
         let key_value_db = KeyValueDB::new(db, config.into(), Some(created_at));
-        Ok(Self {
-            trie: MerkleTree::new(key_value_db)?,
-        })
+        let mut tries = MerkleTrees::<H, DB, ChangeID>::new(key_value_db);
+        for identifier in identifiers {
+            tries.init_tree(&identifier)?;
+        }
+        Ok(Self { tries })
+    }
+
+    /// Initialize a new trie with the given identifier.
+    /// This function is useful when you want to create a new trie in the database without inserting any value.
+    /// If the trie already exists, it will do nothing.
+    /// When you insert a value in a trie, it will automatically create the trie if it doesn't exist.
+    pub fn init_tree(
+        &mut self,
+        identifier: &[u8],
+    ) -> Result<(), BonsaiStorageError<DB::DatabaseError>> {
+        self.tries.init_tree(identifier)
     }
 
     /// Insert a new key/value in the trie, overwriting the previous value if it exists.
     /// If the value already exists it will overwrite it.
     pub fn insert(
         &mut self,
+        identifier: &[u8],
         key: &BitSlice<u8, Msb0>,
         value: &Felt,
     ) -> Result<(), BonsaiStorageError<DB::DatabaseError>> {
-        self.trie.set(key, *value)?;
+        self.tries.set(identifier, key, *value)?;
         Ok(())
     }
 
@@ -212,26 +229,29 @@ where
     /// If the value doesn't exist it will do nothing
     pub fn remove(
         &mut self,
+        identifier: &[u8],
         key: &BitSlice<u8, Msb0>,
     ) -> Result<(), BonsaiStorageError<DB::DatabaseError>> {
-        self.trie.set(key, Felt::ZERO)?;
+        self.tries.set(identifier, key, Felt::ZERO)?;
         Ok(())
     }
 
     /// Get a value in the trie.
     pub fn get(
         &self,
+        identifier: &[u8],
         key: &BitSlice<u8, Msb0>,
     ) -> Result<Option<Felt>, BonsaiStorageError<DB::DatabaseError>> {
-        self.trie.get(key)
+        self.tries.get(identifier, key)
     }
 
     /// Checks if the key exists in the trie.
     pub fn contains(
         &self,
+        identifier: &[u8],
         key: &BitSlice<u8, Msb0>,
     ) -> Result<bool, BonsaiStorageError<DB::DatabaseError>> {
-        self.trie.contains(key)
+        self.tries.contains(identifier, key)
     }
 
     /// Go to a specific commit ID.
@@ -241,7 +261,7 @@ where
         &mut self,
         requested_id: ChangeID,
     ) -> Result<(), BonsaiStorageError<DB::DatabaseError>> {
-        let kv = self.trie.db_mut();
+        let kv = self.tries.db_mut();
 
         // Clear current changes
         kv.changes_store.current_changes.0.clear();
@@ -266,7 +286,14 @@ where
 
         // Accumulate changes from requested to last recorded
         let mut full = Vec::new();
-        for id in kv.changes_store.id_queue.iter().skip(id_position).rev() {
+        for id in kv
+            .changes_store
+            .id_queue
+            .iter()
+            .skip(id_position)
+            .rev()
+            .take_while(|id| *id != &requested_id)
+        {
             full.extend(
                 ChangeBatch::deserialize(
                     id,
@@ -306,7 +333,7 @@ where
 
         // Write revert changes and trie logs truncation
         kv.db.write_batch(batch)?;
-        self.trie.reset_to_last_commit()?;
+        self.tries.reset_to_last_commit()?;
         Ok(())
     }
 
@@ -316,17 +343,20 @@ where
         &self,
         id: ChangeID,
     ) -> Result<HashMap<BitVec<u8, Msb0>, Change>, BonsaiStorageError<DB::DatabaseError>> {
-        self.trie.db_ref().get_changes(id)
+        self.tries.db_ref().get_changes(id)
     }
 
     #[cfg(test)]
     pub fn dump_database(&self) {
-        self.trie.db_ref().db.dump_database();
+        self.tries.db_ref().db.dump_database();
     }
 
     /// Get trie root hash at the latest commit
-    pub fn root_hash(&self) -> Result<BonsaiTrieHash, BonsaiStorageError<DB::DatabaseError>> {
-        Ok(self.trie.root_hash())
+    pub fn root_hash(
+        &self,
+        identifier: &[u8],
+    ) -> Result<BonsaiTrieHash, BonsaiStorageError<DB::DatabaseError>> {
+        self.tries.root_hash(identifier)
     }
 
     /// This function must be used with transactional state only.
@@ -335,8 +365,8 @@ where
         &mut self,
         id: ChangeID,
     ) -> Result<(), BonsaiStorageError<DB::DatabaseError>> {
-        self.trie.commit()?;
-        self.trie.db_mut().commit(id)?;
+        self.tries.commit()?;
+        self.tries.db_mut().commit(id)?;
         Ok(())
     }
 
@@ -353,9 +383,18 @@ where
     ///   3. the root hash matches the known root
     pub fn get_proof(
         &self,
+        identifier: &[u8],
         key: &BitSlice<u8, Msb0>,
     ) -> Result<Vec<ProofNode>, BonsaiStorageError<DB::DatabaseError>> {
-        self.trie.get_proof(key)
+        self.tries.get_proof(identifier, key)
+    }
+
+    /// Get all the keys in a specific trie.
+    pub fn get_keys(
+        &self,
+        identifier: &[u8],
+    ) -> Result<Vec<Vec<u8>>, BonsaiStorageError<DB::DatabaseError>> {
+        self.tries.get_keys(identifier)
     }
 
     /// Verifies a merkle-proof for a given `key` and `value`.
@@ -365,7 +404,7 @@ where
         value: Felt,
         proofs: &[ProofNode],
     ) -> Option<Membership> {
-        MerkleTree::<Pedersen, DB, ChangeID>::verify_proof(root, key, value, proofs)
+        MerkleTree::<Pedersen>::verify_proof(root, key, value, proofs)
     }
 }
 
@@ -373,16 +412,16 @@ impl<ChangeID, DB, H> BonsaiStorage<ChangeID, DB, H>
 where
     DB: BonsaiDatabase + BonsaiPersistentDatabase<ChangeID>,
     ChangeID: id::Id,
-    H: StarkHash,
+    H: StarkHash + Send + Sync,
 {
     /// Update trie and database using all changes since the last commit.
     pub fn commit(
         &mut self,
         id: ChangeID,
     ) -> Result<(), BonsaiStorageError<<DB as BonsaiDatabase>::DatabaseError>> {
-        self.trie.commit()?;
-        self.trie.db_mut().commit(id)?;
-        self.trie.db_mut().create_snapshot(id);
+        self.tries.commit()?;
+        self.tries.db_mut().commit(id)?;
+        self.tries.db_mut().create_snapshot(id);
         Ok(())
     }
 
@@ -399,11 +438,12 @@ where
         Option<BonsaiStorage<ChangeID, DB::Transaction, H>>,
         BonsaiStorageError<<DB::Transaction as BonsaiDatabase>::DatabaseError>,
     > {
-        if let Some(transaction) = self.trie.db_ref().get_transaction(change_id)? {
+        if let Some(transaction) = self.tries.db_ref().get_transaction(change_id)? {
             Ok(Some(BonsaiStorage::new_from_transactional_state(
                 transaction,
                 config,
                 change_id,
+                self.tries.get_identifiers(),
             )?))
         } else {
             Ok(None)
@@ -412,7 +452,7 @@ where
 
     /// Get a copy of the config that can be used to create a transactional state or a new bonsai storage.
     pub fn get_config(&self) -> BonsaiStorageConfig {
-        self.trie.db_ref().get_config().into()
+        self.tries.db_ref().get_config().into()
     }
 
     /// Merge a transactional state into the main trie.
@@ -421,8 +461,8 @@ where
         transactional_bonsai_storage: BonsaiStorage<ChangeID, DB::Transaction, H>,
     ) -> Result<(), BonsaiStorageError<<DB as BonsaiPersistentDatabase<ChangeID>>::DatabaseError>>
     {
-        self.trie
+        self.tries
             .db_mut()
-            .merge(transactional_bonsai_storage.trie.db())
+            .merge(transactional_bonsai_storage.tries.db())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,6 +168,7 @@ where
     tries: MerkleTrees<H, DB, ChangeID>,
 }
 
+#[cfg(feature = "bench")]
 impl<ChangeID, DB, H> Clone for BonsaiStorage<ChangeID, DB, H>
 where
     DB: BonsaiDatabase + Clone,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,6 +168,19 @@ where
     tries: MerkleTrees<H, DB, ChangeID>,
 }
 
+impl<ChangeID, DB, H> Clone for BonsaiStorage<ChangeID, DB, H>
+where
+    DB: BonsaiDatabase + Clone,
+    ChangeID: id::Id,
+    H: StarkHash + Send + Sync,
+{
+    fn clone(&self) -> Self {
+        Self {
+            tries: self.tries.clone(),
+        }
+    }
+}
+
 /// Trie root hash type.
 pub type BonsaiTrieHash = Felt;
 

--- a/src/tests/madara_comparison.rs
+++ b/src/tests/madara_comparison.rs
@@ -10,6 +10,7 @@ use crate::{
 
 #[test]
 fn trie_height_251() {
+    let identifier = vec![];
     let tempdir = tempfile::tempdir().unwrap();
     let db = create_rocks_db(tempdir.path()).unwrap();
     let config = BonsaiStorageConfig::default();
@@ -19,12 +20,14 @@ fn trie_height_251() {
         let mut key: BitVec<u8, Msb0> = bits![u8, Msb0; 0; 251].to_bitvec();
         key.set(i, true);
         let value = Felt::from_hex("0x01").unwrap();
-        bonsai_storage.insert(key.as_bitslice(), &value).unwrap();
+        bonsai_storage
+            .insert(&identifier, key.as_bitslice(), &value)
+            .unwrap();
     }
     let mut id_builder = BasicIdBuilder::new();
     let id = id_builder.new_id();
     bonsai_storage.commit(id).unwrap();
-    bonsai_storage.root_hash().unwrap();
+    bonsai_storage.root_hash(&identifier).unwrap();
 }
 // Test to add on Madara side to check with a tree of height 251 and see that we have same hash
 // #[test]// fn test_height_251() {

--- a/src/tests/proof.rs
+++ b/src/tests/proof.rs
@@ -113,6 +113,7 @@ fn assert_eq_proof(bonsai_proof: &[ProofNode], pathfinder_proof: &[TrieNode]) {
 
 #[test]
 fn basic_proof() {
+    let identifier = vec![];
     let tempdir = tempfile::tempdir().unwrap();
     let db = create_rocks_db(tempdir.path()).unwrap();
     let config = BonsaiStorageConfig::default();
@@ -128,7 +129,9 @@ fn basic_proof() {
         Felt::from_hex("0x66342762FDD54D033c195fec3ce2568b62052e").unwrap(),
     );
     let bitvec = BitVec::from_vec(pair1.0.clone());
-    bonsai_storage.insert(&bitvec, &pair1.1).unwrap();
+    bonsai_storage
+        .insert(&identifier, &bitvec, &pair1.1)
+        .unwrap();
     pathfinder_merkle_tree
         .set(
             &storage,
@@ -141,7 +144,9 @@ fn basic_proof() {
         Felt::from_hex("0x66342762FD54D033c195fec3ce2568b62052e").unwrap(),
     );
     let bitvec = BitVec::from_vec(pair2.0.clone());
-    bonsai_storage.insert(&bitvec, &pair2.1).unwrap();
+    bonsai_storage
+        .insert(&identifier, &bitvec, &pair2.1)
+        .unwrap();
     pathfinder_merkle_tree
         .set(
             &storage,
@@ -154,7 +159,9 @@ fn basic_proof() {
         Felt::from_hex("0x66342762FD54D033c195fec3ce2568b62052e").unwrap(),
     );
     let bitvec = BitVec::from_vec(pair3.0.clone());
-    bonsai_storage.insert(&bitvec, &pair3.1).unwrap();
+    bonsai_storage
+        .insert(&identifier, &bitvec, &pair3.1)
+        .unwrap();
     pathfinder_merkle_tree
         .set(
             &storage,
@@ -165,7 +172,7 @@ fn basic_proof() {
     bonsai_storage.commit(id_builder.new_id()).unwrap();
     let (_, root_id) = commit_and_persist(pathfinder_merkle_tree.clone(), &mut storage);
     let bonsai_proof = bonsai_storage
-        .get_proof(&BitVec::from_vec(vec![1, 2, 1]))
+        .get_proof(&identifier, &BitVec::from_vec(vec![1, 2, 1]))
         .unwrap();
     let pathfinder_proof =
         pathfinder_merkle_tree::tree::MerkleTree::<PedersenHash, 251>::get_proof(
@@ -177,7 +184,7 @@ fn basic_proof() {
     assert_eq_proof(&bonsai_proof, &pathfinder_proof);
     assert_eq!(
         BonsaiStorage::<BasicId, RocksDB<BasicId>, Pedersen>::verify_proof(
-            bonsai_storage.root_hash().unwrap(),
+            bonsai_storage.root_hash(&identifier).unwrap(),
             &BitVec::from_vec(vec![1, 2, 1]),
             pair1.1,
             &bonsai_proof
@@ -188,6 +195,7 @@ fn basic_proof() {
 
 #[test]
 fn multiple_proofs() {
+    let identifier = vec![];
     let tempdir = tempfile::tempdir().unwrap();
     let db = create_rocks_db(tempdir.path()).unwrap();
     let config = BonsaiStorageConfig::default();
@@ -211,7 +219,7 @@ fn multiple_proofs() {
         let value = Felt::from_hex(&element).unwrap();
         let key = &value.to_bytes_be()[..31];
         bonsai_storage
-            .insert(&BitVec::from_vec(key.to_vec()), &value)
+            .insert(&identifier, &BitVec::from_vec(key.to_vec()), &value)
             .unwrap();
         pathfinder_merkle_tree
             .set(
@@ -226,7 +234,7 @@ fn multiple_proofs() {
     let (_, root_id) = commit_and_persist(pathfinder_merkle_tree.clone(), &mut storage);
     for element in elements.iter() {
         let proof = bonsai_storage
-            .get_proof(&BitVec::from_vec(element.0.clone()))
+            .get_proof(&identifier, &BitVec::from_vec(element.0.clone()))
             .unwrap();
         let pathfinder_proof =
             pathfinder_merkle_tree::tree::MerkleTree::<PedersenHash, 251>::get_proof(
@@ -238,7 +246,7 @@ fn multiple_proofs() {
         assert_eq_proof(&proof, &pathfinder_proof);
         assert_eq!(
             BonsaiStorage::<BasicId, RocksDB<BasicId>, Pedersen>::verify_proof(
-                bonsai_storage.root_hash().unwrap(),
+                bonsai_storage.root_hash(&identifier).unwrap(),
                 &BitVec::from_vec(element.0.clone()),
                 element.1,
                 &proof
@@ -250,6 +258,7 @@ fn multiple_proofs() {
 
 #[test]
 fn one_element_proof() {
+    let identifier = vec![];
     let tempdir = tempfile::tempdir().unwrap();
     let db = create_rocks_db(tempdir.path()).unwrap();
     let config = BonsaiStorageConfig::default();
@@ -265,7 +274,9 @@ fn one_element_proof() {
         Felt::from_hex("0x66342762FDD54D033c195fec3ce2568b62052e").unwrap(),
     );
     let bitvec = BitVec::from_vec(pair1.0.clone());
-    bonsai_storage.insert(&bitvec, &pair1.1).unwrap();
+    bonsai_storage
+        .insert(&identifier, &bitvec, &pair1.1)
+        .unwrap();
     pathfinder_merkle_tree
         .set(
             &storage,
@@ -276,7 +287,7 @@ fn one_element_proof() {
     bonsai_storage.commit(id_builder.new_id()).unwrap();
     let (_, root_id) = commit_and_persist(pathfinder_merkle_tree.clone(), &mut storage);
     let bonsai_proof = bonsai_storage
-        .get_proof(&BitVec::from_vec(vec![1, 2, 1]))
+        .get_proof(&identifier, &BitVec::from_vec(vec![1, 2, 1]))
         .unwrap();
     let pathfinder_proof =
         pathfinder_merkle_tree::tree::MerkleTree::<PedersenHash, 251>::get_proof(
@@ -288,7 +299,7 @@ fn one_element_proof() {
     assert_eq_proof(&bonsai_proof, &pathfinder_proof);
     assert_eq!(
         BonsaiStorage::<BasicId, RocksDB<BasicId>, Pedersen>::verify_proof(
-            bonsai_storage.root_hash().unwrap(),
+            bonsai_storage.root_hash(&identifier).unwrap(),
             &BitVec::from_vec(vec![1, 2, 1]),
             pair1.1,
             &bonsai_proof
@@ -299,6 +310,7 @@ fn one_element_proof() {
 
 #[test]
 fn zero_not_crashing() {
+    let identifier = vec![];
     let tempdir = tempfile::tempdir().unwrap();
     let db = create_rocks_db(tempdir.path()).unwrap();
     let config = BonsaiStorageConfig::default();
@@ -308,6 +320,6 @@ fn zero_not_crashing() {
     let mut id_builder = BasicIdBuilder::new();
     bonsai_storage.commit(id_builder.new_id()).unwrap();
     bonsai_storage
-        .get_proof(&BitVec::from_vec(vec![1, 2, 1]))
-        .unwrap();
+        .get_proof(&identifier, &BitVec::from_vec(vec![1, 2, 1]))
+        .expect_err("Should error");
 }

--- a/src/tests/simple.rs
+++ b/src/tests/simple.rs
@@ -4,11 +4,12 @@ use crate::{
     id::{BasicId, BasicIdBuilder},
     BonsaiStorage, BonsaiStorageConfig, Change,
 };
-use bitvec::{vec::BitVec, view::BitView};
+use bitvec::{order::Msb0, vec::BitVec, view::BitView};
 use starknet_types_core::{felt::Felt, hash::Pedersen};
 
 #[test]
 fn basics() {
+    let identifier = vec![];
     let tempdir = tempfile::tempdir().unwrap();
     let db = create_rocks_db(tempdir.path()).unwrap();
     let config = BonsaiStorageConfig::default();
@@ -20,41 +21,49 @@ fn basics() {
         Felt::from_hex("0x66342762FDD54D033c195fec3ce2568b62052e").unwrap(),
     );
     let bitvec = BitVec::from_vec(pair1.0.clone());
-    bonsai_storage.insert(&bitvec, &pair1.1).unwrap();
+    bonsai_storage
+        .insert(&identifier, &bitvec, &pair1.1)
+        .unwrap();
     bonsai_storage.commit(id_builder.new_id()).unwrap();
     let pair2 = (
         vec![1, 2, 2],
         Felt::from_hex("0x66342762FD54D033c195fec3ce2568b62052e").unwrap(),
     );
     let bitvec = BitVec::from_vec(pair2.0.clone());
-    bonsai_storage.insert(&bitvec, &pair2.1).unwrap();
+    bonsai_storage
+        .insert(&identifier, &bitvec, &pair2.1)
+        .unwrap();
     bonsai_storage.commit(id_builder.new_id()).unwrap();
     let pair3 = (
         vec![1, 2, 3],
         Felt::from_hex("0x66342762FD54D033c195fec3ce2568b62052e").unwrap(),
     );
     let bitvec = BitVec::from_vec(pair3.0.clone());
-    bonsai_storage.insert(&bitvec, &pair3.1).unwrap();
+    bonsai_storage
+        .insert(&identifier, &bitvec, &pair3.1)
+        .unwrap();
     bonsai_storage.commit(id_builder.new_id()).unwrap();
     let bitvec = BitVec::from_vec(vec![1, 2, 1]);
-    bonsai_storage.remove(&bitvec).unwrap();
+    bonsai_storage.remove(&identifier, &bitvec).unwrap();
     assert_eq!(
         bonsai_storage
-            .get(&BitVec::from_vec(vec![1, 2, 1]))
+            .get(&identifier, &BitVec::from_vec(vec![1, 2, 1]))
             .unwrap(),
         None
     );
     bonsai_storage.commit(id_builder.new_id()).unwrap();
     assert_eq!(
         bonsai_storage
-            .get(&BitVec::from_vec(vec![1, 2, 1]))
+            .get(&identifier, &BitVec::from_vec(vec![1, 2, 1]))
             .unwrap(),
         None
     );
+    assert_eq!(bonsai_storage.get_keys(&identifier).unwrap().len(), 2);
 }
 
 #[test]
 fn root_hash_similar_rocks_db() {
+    let identifier = vec![];
     let root_hash_1 = {
         let tempdir = tempfile::tempdir().unwrap();
         let db = create_rocks_db(tempdir.path()).unwrap();
@@ -68,14 +77,18 @@ fn root_hash_similar_rocks_db() {
                 .unwrap(),
         );
         let bitvec = BitVec::from_vec(pair1.0.clone());
-        bonsai_storage.insert(&bitvec, &pair1.1).unwrap();
+        bonsai_storage
+            .insert(&identifier, &bitvec, &pair1.1)
+            .unwrap();
         let pair2 = (
             vec![1, 2, 2],
             Felt::from_hex("0x100bd6fbfced88ded1b34bd1a55b747ce3a9fde9a914bca75571e4496b56443")
                 .unwrap(),
         );
         let bitvec = BitVec::from_vec(pair2.0.clone());
-        bonsai_storage.insert(&bitvec, &pair2.1).unwrap();
+        bonsai_storage
+            .insert(&identifier, &bitvec, &pair2.1)
+            .unwrap();
         bonsai_storage.commit(id_builder.new_id()).unwrap();
         let pair3 = (
             vec![1, 2, 3],
@@ -83,16 +96,20 @@ fn root_hash_similar_rocks_db() {
                 .unwrap(),
         );
         let bitvec = BitVec::from_vec(pair3.0.clone());
-        bonsai_storage.insert(&bitvec, &pair3.1).unwrap();
+        bonsai_storage
+            .insert(&identifier, &bitvec, &pair3.1)
+            .unwrap();
         let pair4 = (
             vec![1, 2, 4],
             Felt::from_hex("0x02808c7d8f3745e55655ad3f51f096d0c06a41f3d76caf96bad80f9be9ced171")
                 .unwrap(),
         );
         let bitvec = BitVec::from_vec(pair4.0.clone());
-        bonsai_storage.insert(&bitvec, &pair4.1).unwrap();
+        bonsai_storage
+            .insert(&identifier, &bitvec, &pair4.1)
+            .unwrap();
         bonsai_storage.commit(id_builder.new_id()).unwrap();
-        bonsai_storage.root_hash().unwrap()
+        bonsai_storage.root_hash(&identifier).unwrap()
     };
     let root_hash_2 = {
         let tempdir = tempfile::tempdir().unwrap();
@@ -107,16 +124,20 @@ fn root_hash_similar_rocks_db() {
                 .unwrap(),
         );
         let bitvec = BitVec::from_vec(pair1.0.clone());
-        bonsai_storage.insert(&bitvec, &pair1.1).unwrap();
+        bonsai_storage
+            .insert(&identifier, &bitvec, &pair1.1)
+            .unwrap();
         let pair2 = (
             vec![1, 2, 4],
             Felt::from_hex("0x02808c7d8f3745e55655ad3f51f096d0c06a41f3d76caf96bad80f9be9ced171")
                 .unwrap(),
         );
         let bitvec = BitVec::from_vec(pair2.0.clone());
-        bonsai_storage.insert(&bitvec, &pair2.1).unwrap();
+        bonsai_storage
+            .insert(&identifier, &bitvec, &pair2.1)
+            .unwrap();
         bonsai_storage.commit(id_builder.new_id()).unwrap();
-        bonsai_storage.root_hash().unwrap()
+        bonsai_storage.root_hash(&identifier).unwrap()
     };
     println!("root_hash_1: {:?}", root_hash_1.to_string());
     println!("root_hash_2: {:?}", root_hash_2.to_string());
@@ -129,6 +150,7 @@ fn starknet_specific() {
         address: &'static str,
         state_hash: &'static str,
     }
+    let identifier = vec![];
 
     let tempdir1 = tempfile::tempdir().unwrap();
     let db1 = create_rocks_db(tempdir1.path()).unwrap();
@@ -160,10 +182,10 @@ fn starknet_specific() {
         let key = Felt::from_hex(key).unwrap().to_bytes_be().view_bits()[5..].to_bitvec();
         let value = Felt::from_hex(value).unwrap();
         bonsai_storage1
-            .insert(&key, &value)
+            .insert(&identifier, &key, &value)
             .expect("Failed to insert storage update into trie");
         bonsai_storage2
-            .insert(&key, &value)
+            .insert(&identifier, &key, &value)
             .expect("Failed to insert storage update into trie");
     }
 
@@ -184,10 +206,10 @@ fn starknet_specific() {
         let value = Felt::from_hex(value).unwrap();
 
         bonsai_storage1
-            .insert(&key, &value)
+            .insert(&identifier, &key, &value)
             .expect("Failed to insert storage update into trie");
         bonsai_storage2
-            .insert(&key, &value)
+            .insert(&identifier, &key, &value)
             .expect("Failed to insert storage update into trie");
     }
 
@@ -196,20 +218,21 @@ fn starknet_specific() {
         .commit(id)
         .expect("Failed to commit to bonsai storage");
     let root_hash1 = bonsai_storage1
-        .root_hash()
+        .root_hash(&identifier)
         .expect("Failed to get root hash");
 
     bonsai_storage2
         .commit(id)
         .expect("Failed to commit to bonsai storage");
     let root_hash2 = bonsai_storage2
-        .root_hash()
+        .root_hash(&identifier)
         .expect("Failed to get root hash");
     assert_eq!(root_hash1, root_hash2);
 }
 
 #[test]
 fn root_hash_similar_hashmap_db() {
+    let identifier = vec![];
     let root_hash_1 = {
         let db = HashMapDb::<BasicId>::default();
         let config = BonsaiStorageConfig::default();
@@ -222,14 +245,18 @@ fn root_hash_similar_hashmap_db() {
                 .unwrap(),
         );
         let bitvec = BitVec::from_vec(pair1.0.clone());
-        bonsai_storage.insert(&bitvec, &pair1.1).unwrap();
+        bonsai_storage
+            .insert(&identifier, &bitvec, &pair1.1)
+            .unwrap();
         let pair2 = (
             vec![1, 2, 2],
             Felt::from_hex("0x100bd6fbfced88ded1b34bd1a55b747ce3a9fde9a914bca75571e4496b56443")
                 .unwrap(),
         );
         let bitvec = BitVec::from_vec(pair2.0.clone());
-        bonsai_storage.insert(&bitvec, &pair2.1).unwrap();
+        bonsai_storage
+            .insert(&identifier, &bitvec, &pair2.1)
+            .unwrap();
         bonsai_storage.commit(id_builder.new_id()).unwrap();
         let pair3 = (
             vec![1, 2, 3],
@@ -237,16 +264,20 @@ fn root_hash_similar_hashmap_db() {
                 .unwrap(),
         );
         let bitvec = BitVec::from_vec(pair3.0.clone());
-        bonsai_storage.insert(&bitvec, &pair3.1).unwrap();
+        bonsai_storage
+            .insert(&identifier, &bitvec, &pair3.1)
+            .unwrap();
         let pair4 = (
             vec![1, 2, 4],
             Felt::from_hex("0x02808c7d8f3745e55655ad3f51f096d0c06a41f3d76caf96bad80f9be9ced171")
                 .unwrap(),
         );
         let bitvec = BitVec::from_vec(pair4.0.clone());
-        bonsai_storage.insert(&bitvec, &pair4.1).unwrap();
+        bonsai_storage
+            .insert(&identifier, &bitvec, &pair4.1)
+            .unwrap();
         bonsai_storage.commit(id_builder.new_id()).unwrap();
-        bonsai_storage.root_hash().unwrap()
+        bonsai_storage.root_hash(&identifier).unwrap()
     };
     let root_hash_2 = {
         let db = HashMapDb::<BasicId>::default();
@@ -260,16 +291,20 @@ fn root_hash_similar_hashmap_db() {
                 .unwrap(),
         );
         let bitvec = BitVec::from_vec(pair1.0.clone());
-        bonsai_storage.insert(&bitvec, &pair1.1).unwrap();
+        bonsai_storage
+            .insert(&identifier, &bitvec, &pair1.1)
+            .unwrap();
         let pair2 = (
             vec![1, 2, 4],
             Felt::from_hex("0x02808c7d8f3745e55655ad3f51f096d0c06a41f3d76caf96bad80f9be9ced171")
                 .unwrap(),
         );
         let bitvec = BitVec::from_vec(pair2.0.clone());
-        bonsai_storage.insert(&bitvec, &pair2.1).unwrap();
+        bonsai_storage
+            .insert(&identifier, &bitvec, &pair2.1)
+            .unwrap();
         bonsai_storage.commit(id_builder.new_id()).unwrap();
-        bonsai_storage.root_hash().unwrap()
+        bonsai_storage.root_hash(&identifier).unwrap()
     };
     println!("root_hash_1: {:?}", root_hash_1.to_string());
     println!("root_hash_2: {:?}", root_hash_2.to_string());
@@ -278,6 +313,7 @@ fn root_hash_similar_hashmap_db() {
 
 #[test]
 fn double_insert() {
+    let identifier = vec![];
     struct ContractState {
         address: &'static str,
         state_hash: &'static str,
@@ -320,21 +356,96 @@ fn double_insert() {
         let bitkey = key.to_bytes_be().view_bits()[5..].to_bitvec();
         let value = Felt::from_hex(value).unwrap();
         bonsai_storage
-            .insert(&bitkey, &value)
+            .insert(&identifier, &bitkey, &value)
             .expect("Failed to insert storage update into trie");
         // fails here for key 0x313ad57fdf765addc71329abf8d74ac2bce6d46da8c2b9b82255a5076620301
         // and value 0x453ae0c9610197b18b13645c44d3d0a407083d96562e8752aab3fab616cecb0
-        bonsai_storage.insert(&bitkey, &value).expect(&format!(
-            "Failed to insert storage update into trie for key {key:#x} & value {value:#x}"
-        ));
+        bonsai_storage
+            .insert(&identifier, &bitkey, &value)
+            .unwrap_or_else(|_| {
+                panic!(
+                    "Failed to insert storage update into trie for key {key:#x} & value {value:#x}"
+                )
+            });
     }
     bonsai_storage.commit(id_builder.new_id()).unwrap();
-    let root_hash = bonsai_storage.root_hash().unwrap();
+    let root_hash = bonsai_storage.root_hash(&identifier).unwrap();
     println!("root hash: {root_hash:#x}");
 }
 
 #[test]
+fn double_identifier() {
+    let identifier = vec![2, 3];
+    let identifier2 = vec![1, 3, 1];
+    struct ContractState {
+        address: &'static str,
+        state_hash: &'static str,
+    }
+    let tempdir = tempfile::tempdir().unwrap();
+    let db = create_rocks_db(tempdir.path()).unwrap();
+    let config = BonsaiStorageConfig::default();
+    let mut bonsai_storage: BonsaiStorage<_, _, Pedersen> =
+        BonsaiStorage::new(RocksDB::new(&db, RocksDBConfig::default()), config).unwrap();
+    let mut id_builder = BasicIdBuilder::new();
+    let contract_states = vec![
+        ContractState {
+            address: "0x0000000000000000000000000000000000000000000000000000000000000005",
+            state_hash: "0x000000000000000000000000000000000000000000000000000000000000022b",
+        },
+        ContractState {
+            address: "0x0313ad57fdf765addc71329abf8d74ac2bce6d46da8c2b9b82255a5076620300",
+            state_hash: "0x04e7e989d58a17cd279eca440c5eaa829efb6f9967aaad89022acbe644c39b36",
+        },
+        // This seems to be what is causing the problem in case of double insertions.
+        // Other value are fine
+        ContractState {
+            address: "0x313ad57fdf765addc71329abf8d74ac2bce6d46da8c2b9b82255a5076620301",
+            state_hash: "0x453ae0c9610197b18b13645c44d3d0a407083d96562e8752aab3fab616cecb0",
+        },
+        ContractState {
+            address: "0x05aee31408163292105d875070f98cb48275b8c87e80380b78d30647e05854d5",
+            state_hash: "0x00000000000000000000000000000000000000000000000000000000000007e5",
+        },
+        ContractState {
+            address: "0x06cf6c2f36d36b08e591e4489e92ca882bb67b9c39a3afccf011972a8de467f0",
+            state_hash: "0x07ab344d88124307c07b56f6c59c12f4543e9c96398727854a322dea82c73240",
+        },
+    ];
+    for contract_state in contract_states {
+        let key = contract_state.address;
+        let value = contract_state.state_hash;
+
+        let key = Felt::from_hex(key).unwrap();
+        let bitkey = key.to_bytes_be().view_bits()[5..].to_bitvec();
+        let value = Felt::from_hex(value).unwrap();
+        bonsai_storage
+            .insert(&identifier, &bitkey, &value)
+            .expect("Failed to insert storage update into trie");
+        // fails here for key 0x313ad57fdf765addc71329abf8d74ac2bce6d46da8c2b9b82255a5076620301
+        // and value 0x453ae0c9610197b18b13645c44d3d0a407083d96562e8752aab3fab616cecb0
+        bonsai_storage
+            .insert(&identifier2, &bitkey, &value)
+            .unwrap_or_else(|_| {
+                panic!(
+                    "Failed to insert storage update into trie for key {key:#x} & value {value:#x}"
+                )
+            });
+    }
+    bonsai_storage.commit(id_builder.new_id()).unwrap();
+    let root_hash = bonsai_storage.root_hash(&identifier).unwrap();
+    println!("root hash: {root_hash:#x}");
+    let root_hash2 = bonsai_storage.root_hash(&identifier2).unwrap();
+    assert_eq!(root_hash, root_hash2);
+    assert_eq!(
+        bonsai_storage.get_keys(&identifier).unwrap(),
+        bonsai_storage.get_keys(&identifier2).unwrap()
+    );
+    assert_eq!(bonsai_storage.get_keys(&identifier).unwrap().len(), 5);
+}
+
+#[test]
 fn get_changes() {
+    let identifier = vec![];
     let tempdir = tempfile::tempdir().unwrap();
     let db = create_rocks_db(tempdir.path()).unwrap();
     let config = BonsaiStorageConfig::default();
@@ -343,17 +454,25 @@ fn get_changes() {
     let mut id_builder = BasicIdBuilder::new();
     let pair1 = (vec![1, 2, 1], Felt::from_hex("0x01").unwrap());
     let bitvec = BitVec::from_vec(pair1.0.clone());
-    bonsai_storage.insert(&bitvec, &pair1.1).unwrap();
+    bonsai_storage
+        .insert(&identifier, &bitvec, &pair1.1)
+        .unwrap();
     bonsai_storage.commit(id_builder.new_id()).unwrap();
     let pair2 = (vec![1, 2, 2], Felt::from_hex("0x01").unwrap());
     let bitvec = BitVec::from_vec(pair2.0.clone());
-    bonsai_storage.insert(&bitvec, &pair2.1).unwrap();
+    bonsai_storage
+        .insert(&identifier, &bitvec, &pair2.1)
+        .unwrap();
     let pair1_edited_1 = (vec![1, 2, 1], Felt::from_hex("0x02").unwrap());
     let bitvec = BitVec::from_vec(pair1_edited_1.0.clone());
-    bonsai_storage.insert(&bitvec, &pair1_edited_1.1).unwrap();
+    bonsai_storage
+        .insert(&identifier, &bitvec, &pair1_edited_1.1)
+        .unwrap();
     let pair1_edited_2 = (vec![1, 2, 1], Felt::from_hex("0x03").unwrap());
     let bitvec = BitVec::from_vec(pair1_edited_2.0.clone());
-    bonsai_storage.insert(&bitvec, &pair1_edited_2.1).unwrap();
+    bonsai_storage
+        .insert(&identifier, &bitvec, &pair1_edited_2.1)
+        .unwrap();
     let id = id_builder.new_id();
     bonsai_storage.commit(id).unwrap();
     let changes = bonsai_storage.get_changes(id).unwrap();
@@ -371,5 +490,562 @@ fn get_changes() {
             old_value: None,
             new_value: Some(pair2.1),
         }
+    );
+}
+
+fn keyer(felt: Felt) -> BitVec<u8, Msb0> {
+    felt.to_bytes_be().view_bits()[5..].to_bitvec()
+}
+
+#[test]
+fn test_insert_zero() {
+    let config = BonsaiStorageConfig::default();
+    let bonsai_db = HashMapDb::<BasicId>::default();
+    let mut bonsai_storage = BonsaiStorage::<_, _, Pedersen>::new(bonsai_db, config)
+        .expect("Failed to create bonsai storage");
+    let identifier =
+        "0x056e4fed965fccd7fb01fcadd827470338f35ced62275328929d0d725b5707ba".as_bytes();
+
+    // Insert Block 3 storage changes for contract `0x056e4fed965fccd7fb01fcadd827470338f35ced62275328929d0d725b5707ba`
+    let block_3 = [
+        ("0x5", "0x456"),
+        (
+            "0x378e096bb5e74b0f4ca78660a6b49b4a8035e571b024c018713c80b4b969735",
+            "0x205d119502a165dae3830f627fa93fbdf5bfb13edd8f00e4c72621d0cda24",
+        ),
+        (
+            "0x41139bbf557d599fe8e96983251ecbfcb5bf4c4138c85946b0c4a6a68319f24",
+            "0x7eec291f712520293664c7e3a8bb39ab00babf51cb0d9c1fb543147f37b485f",
+        ),
+        (
+            "0x77ae79c60260b3e48516a7da1aa173ac2765a5ced420f8ffd1539c394fbc03c",
+            "0x6025343ab6a7ac36acde4eba3b6fc21f53d5302ee26e6f28e8de5a62bbfd847",
+        ),
+        (
+            "0x751901aac66fdc1f455c73022d02f1c085602cd0c9acda907cfca5418769e9c",
+            "0x3f23078d48a4bf1d5f8ca0348f9efe9300834603625a379cae5d6d81100adef",
+        ),
+        (
+            "0x751901aac66fdc1f455c73022d02f1c085602cd0c9acda907cfca5418769e9d",
+            "0xbd858a06904cadc3787ecbad97409606dcee50ea6fc30b94930bcf3d8843d5",
+        ),
+    ];
+
+    for (key_hex, value_hex) in block_3.iter() {
+        let key: Felt = Felt::from_hex(key_hex).unwrap();
+        let value = Felt::from_hex(value_hex).unwrap();
+        bonsai_storage
+            .insert(identifier, keyer(key).as_bitslice(), &value)
+            .expect("Failed to insert storage update into trie");
+    }
+
+    let mut id_builder = BasicIdBuilder::new();
+    let id = id_builder.new_id();
+    bonsai_storage
+        .commit(id)
+        .expect("Failed to commit to bonsai storage");
+    let root_hash = bonsai_storage
+        .root_hash(identifier)
+        .expect("Failed to get root hash");
+
+    println!(
+        "Expected: 0x069064A05C14A9A2B4ED81C479C14D30872A9AE9CE2DEA8E4B4509542C2DCC1F\nFound: {root_hash:#x}",
+    );
+    assert_eq!(
+        root_hash,
+        Felt::from_hex("0x069064A05C14A9A2B4ED81C479C14D30872A9AE9CE2DEA8E4B4509542C2DCC1F")
+            .unwrap()
+    );
+
+    // Insert Block 4 storage changes for contract `0x056e4fed965fccd7fb01fcadd827470338f35ced62275328929d0d725b5707ba`
+    let block_4 = [
+        ("0x5", "0x0"), // Inserting key = 0x0
+        (
+            "0x4b81c1bca2d1b7e08535a5abe231b2e94399674db5e8f1d851fd8f4af4abd34",
+            "0x7c7",
+        ),
+        (
+            "0x6f8cf54aaec1f42d5f3868d597fcd7393da888264dc5a6e93c7bd528b6d6fee",
+            "0x7e5",
+        ),
+        (
+            "0x2a315469199dfde4b05906db8c33f6962916d462d8f1cf5252b748dfa174a20",
+            "0xdae79d0308bb710af439eb36e82b405dc2bca23b351d08b4867d9525226e9d",
+        ),
+        (
+            "0x2d1ed96c7561dd8e5919657790ffba8473b80872fea3f7ef8279a7253dc3b33",
+            "0x750387f4d66b0e9be1f2f330e8ad309733c46bb74e0be4df0a8c58fb4e89a25",
+        ),
+        (
+            "0x6a93bcb89fc1f31fa544377c7de6de1dd3e726e1951abc95c4984995e84ad0d",
+            "0x7e5",
+        ),
+        (
+            "0x6b3b4780013c33cdca6799e8aa3ef922b64f5a2d356573b33693d81504deccf",
+            "0x7c7",
+        ),
+    ];
+
+    for (key_hex, value_hex) in block_4.iter() {
+        let key: Felt = Felt::from_hex(key_hex).unwrap();
+        let value = Felt::from_hex(value_hex).unwrap();
+        bonsai_storage
+            .insert(identifier, keyer(key).as_bitslice(), &value)
+            .expect("Failed to insert storage update into trie");
+    }
+
+    let id = id_builder.new_id();
+    bonsai_storage
+        .commit(id)
+        .expect("Failed to commit to bonsai storage");
+    let root_hash = bonsai_storage
+        .root_hash(identifier)
+        .expect("Failed to get root hash");
+
+    println!(
+        "Expected: 0x0112998A41A3A2C720E758F82D184E4C39E9382620F12076B52C516D14622E57\nFound: {root_hash:#x}",
+    );
+    assert_eq!(
+        root_hash,
+        Felt::from_hex("0x0112998A41A3A2C720E758F82D184E4C39E9382620F12076B52C516D14622E57")
+            .unwrap()
+    );
+
+    // Insert Block 5 storage changes for contract `0x056e4fed965fccd7fb01fcadd827470338f35ced62275328929d0d725b5707ba`
+    let block_5 = [("0x5", "0x456")];
+
+    for (key_hex, value_hex) in block_5.iter() {
+        let key: Felt = Felt::from_hex(key_hex).unwrap();
+        let value = Felt::from_hex(value_hex).unwrap();
+        bonsai_storage
+            .insert(identifier, keyer(key).as_bitslice(), &value)
+            .expect("Failed to insert storage update into trie");
+    }
+
+    let id = id_builder.new_id();
+    bonsai_storage
+        .commit(id)
+        .expect("Failed to commit to bonsai storage");
+    let root_hash = bonsai_storage
+        .root_hash(identifier)
+        .expect("Failed to get root hash");
+
+    println!(
+        "Expected: 0x072E79A6F71E3E63D7DE40EDF4322A22E64388D4D5BFE817C1271C78028B73BF\nFound: {root_hash:#x}"
+    );
+    assert_eq!(
+        root_hash,
+        Felt::from_hex("0x072E79A6F71E3E63D7DE40EDF4322A22E64388D4D5BFE817C1271C78028B73BF")
+            .unwrap()
+    );
+}
+
+#[test]
+fn test_block_7_starknet() {
+    let config = BonsaiStorageConfig::default();
+    let bonsai_db = HashMapDb::<BasicId>::default();
+    let mut bonsai_storage = BonsaiStorage::<_, _, Pedersen>::new(bonsai_db, config)
+        .expect("Failed to create bonsai storage");
+    let identifier =
+        "0x056e4fed965fccd7fb01fcadd827470338f35ced62275328929d0d725b5707ba".as_bytes();
+
+    // Insert Block 3 storage changes for contract `0x4d56b8ac0ed905936da10323328cba5def12957a2936920f043d8bf6a1e902d`
+    let block_3 = [
+        (
+            "0x67c2665fbdd32ded72c0665f9658c05a5f9233c8de2002b3eba8ae046174efd",
+            "0x2221def5413ed3e128051d5dff3ec816dbfb9db4454b98f4aa47804cb7a13d2",
+        ),
+        ("0x5", "0x66"),
+        (
+            "0x101c2b102c8eb6bf091f5debcf97d8edde85983e23f9778e9cabbe0b5a4f997",
+            "0x99a58a9612fe930f39c4c399b6be14e8bb7c8229d06eab8d0a3a97877a6667",
+        ),
+        (
+            "0x1aabd3b2e12959bab2c4ab530c1d8f0e675e0dc5ab29d1f10b7f1a154cabef9",
+            "0x41d4ae0ba9013f2f6e1551b62a9c9187053727e0e65217be97eae8922d5b2df",
+        ),
+        (
+            "0x1aabd3b2e12959bab2c4ab530c1d8f0e675e0dc5ab29d1f10b7f1a154cabefa",
+            "0x6eda96627bd3de7af5b4f932ff1e858bd396c897229d64b6dd3f0f936f0ea17",
+        ),
+    ];
+
+    for (key_hex, value_hex) in block_3.iter() {
+        let key = Felt::from_hex(key_hex).unwrap();
+        let value = Felt::from_hex(value_hex).unwrap();
+        bonsai_storage
+            .insert(identifier, keyer(key).as_bitslice(), &value)
+            .expect("Failed to insert storage update into trie");
+    }
+
+    let mut id_builder = BasicIdBuilder::new();
+    let id = id_builder.new_id();
+    bonsai_storage
+        .commit(id)
+        .expect("Failed to commit to bonsai storage");
+    let root_hash = bonsai_storage
+        .root_hash(identifier)
+        .expect("Failed to get root hash");
+
+    println!("Expected: 0x0297DE74ABD178CAF7EA2F1AE1B4588CA7433B1B11A98172B6F56E3E02739FD0\nFound: {root_hash:#x}");
+    assert_eq!(
+        root_hash,
+        Felt::from_hex("0x0297DE74ABD178CAF7EA2F1AE1B4588CA7433B1B11A98172B6F56E3E02739FD0")
+            .unwrap()
+    );
+
+    // Insert Block 4 storage changes for contract `0x4d56b8ac0ed905936da10323328cba5def12957a2936920f043d8bf6a1e902d`
+    let block_4 = [
+        (
+            "0x3c14ddc99b06b00340bffd81ef1c4e10f74b800a911ee22c22bb28e4b516da5",
+            "0x7e5",
+        ),
+        ("0x5", "0x64"),
+        (
+            "0x5201dd2a5f567a653e9a2b7a62816919d0d695d1e2f39d516f9befda30da720",
+            "0x29ed6ea046ebe50aaacb9cd6477ac368644c8f4242ee0687d31f6c2ac20c146",
+        ),
+        (
+            "0x5b3856459ac954d3fd24d85924d978263709880e3ee4cafdfe0b7c95ee6b26a",
+            "0x4c90411b3376d5230a88496e58acf58c19431d52b89f1ab91924075f4b35ac1",
+        ),
+        (
+            "0x5b3856459ac954d3fd24d85924d978263709880e3ee4cafdfe0b7c95ee6b26b",
+            "0x72a56d83fab34872a880dd35d936117a084b928fb9d47306abb2558472633c",
+        ),
+        (
+            "0x6a93bcb89fc1f31fa544377c7de6de1dd3e726e1951abc95c4984995e84ad0d",
+            "0x7c7",
+        ),
+        (
+            "0x6f8cf54aaec1f42d5f3868d597fcd7393da888264dc5a6e93c7bd528b6d6fee",
+            "0x7c7",
+        ),
+        (
+            "0x6b30a5f1341c0c949f847afe7f761a6ea8cdc3337baa20e68a2891f62389052",
+            "0x7e5",
+        ),
+        (
+            "0x6b3b4780013c33cdca6799e8aa3ef922b64f5a2d356573b33693d81504deccf",
+            "0x7e5",
+        ),
+        (
+            "0x6f649e057570e0f3cc710d260c2067297542f8e18407a7e75008808e12e6099",
+            "0x61395ebfa1746f9449711a7e361254ddb90f642861807b7e5e05276c11033ec",
+        ),
+        (
+            "0x6f649e057570e0f3cc710d260c2067297542f8e18407a7e75008808e12e609a",
+            "0x304d0ec8cc0ea6faf0f7ad67903bcffc6bc4474d25f93e1c961b239370b8c07",
+        ),
+    ];
+
+    for (key_hex, value_hex) in block_4.iter() {
+        let key = Felt::from_hex(key_hex).unwrap();
+        let value = Felt::from_hex(value_hex).unwrap();
+        bonsai_storage
+            .insert(identifier, keyer(key).as_bitslice(), &value)
+            .expect("Failed to insert storage update into trie");
+    }
+
+    let id = id_builder.new_id();
+    bonsai_storage
+        .commit(id)
+        .expect("Failed to commit to bonsai storage");
+    let root_hash = bonsai_storage
+        .root_hash(identifier)
+        .expect("Failed to get root hash");
+
+    println!("Expected: 0x07A4CA1440AF3858CEB11386BA7E2A0FC553BB73E741043218845D820009BCCB\nFound: {root_hash:#x}");
+    assert_eq!(
+        root_hash,
+        Felt::from_hex("0x07A4CA1440AF3858CEB11386BA7E2A0FC553BB73E741043218845D820009BCCB")
+            .unwrap()
+    );
+
+    // Insert Block 5 storage changes for contract `0x4d56b8ac0ed905936da10323328cba5def12957a2936920f043d8bf6a1e902d`
+    let block_5 = [
+        (
+            "0x272cd29c23c7fd72ef13352ac037c6fabfee4c03056ea413c326be6501b4f31",
+            "0x7c7",
+        ),
+        (
+            "0x2bb6a7dd9cbb9cec8fdad9c0557bd539683f7ea65d4f14d41fe4d72311775e3",
+            "0x7e5",
+        ),
+    ];
+
+    for (key_hex, value_hex) in block_5.iter() {
+        let key = Felt::from_hex(key_hex).unwrap();
+        let value = Felt::from_hex(value_hex).unwrap();
+        bonsai_storage
+            .insert(identifier, keyer(key).as_bitslice(), &value)
+            .expect("Failed to insert storage update into trie");
+    }
+
+    let id = id_builder.new_id();
+    bonsai_storage
+        .commit(id)
+        .expect("Failed to commit to bonsai storage");
+    let root_hash = bonsai_storage
+        .root_hash(identifier)
+        .expect("Failed to get root hash");
+
+    println!("Expected: 0x002363DCD04D065C6B50A4D46F930EBC91AC7F4B15DCF1B0A8D0165B0BA0F143\nFound: {root_hash:#x}");
+    assert_eq!(
+        root_hash,
+        Felt::from_hex("0x002363DCD04D065C6B50A4D46F930EBC91AC7F4B15DCF1B0A8D0165B0BA0F143")
+            .unwrap()
+    );
+
+    // Insert Block 6 storage changes for contract `0x4d56b8ac0ed905936da10323328cba5def12957a2936920f043d8bf6a1e902d`
+    let block_6 = [("0x5", "0x22b")];
+
+    for (key_hex, value_hex) in block_6.iter() {
+        let key = Felt::from_hex(key_hex).unwrap();
+        let value = Felt::from_hex(value_hex).unwrap();
+        bonsai_storage
+            .insert(identifier, keyer(key).as_bitslice(), &value)
+            .expect("Failed to insert storage update into trie");
+    }
+
+    let id = id_builder.new_id();
+    bonsai_storage
+        .commit(id)
+        .expect("Failed to commit to bonsai storage");
+    let root_hash = bonsai_storage
+        .root_hash(identifier)
+        .expect("Failed to get root hash");
+
+    println!("Expected: 0x00C656C01BB43291BEA976CEACE3AFE89A5621045E3B6F23E4BCFFFBB4B66832\nFound: {root_hash:#x}");
+    assert_eq!(
+        root_hash,
+        Felt::from_hex("0x00C656C01BB43291BEA976CEACE3AFE89A5621045E3B6F23E4BCFFFBB4B66832")
+            .unwrap()
+    );
+
+    // Insert Block 6 storage changes for contract `0x4d56b8ac0ed905936da10323328cba5def12957a2936920f043d8bf6a1e902d`
+    let block_7 = [("0x5", "0x0")];
+
+    for (key_hex, value_hex) in block_7.iter() {
+        let key = Felt::from_hex(key_hex).unwrap();
+        let value = Felt::from_hex(value_hex).unwrap();
+        bonsai_storage
+            .insert(identifier, keyer(key).as_bitslice(), &value)
+            .expect("Failed to insert storage update into trie");
+    }
+
+    let id = id_builder.new_id();
+    bonsai_storage
+        .commit(id)
+        .expect("Failed to commit to bonsai storage");
+    let root_hash = bonsai_storage
+        .root_hash(identifier)
+        .expect("Failed to get root hash");
+
+    println!("Expected: 0x032C61E78534A30DD005DB4B9136AA64893CC2F6E10C4535DD6F29BFB2ADC726\nFound: {root_hash:#x}");
+    assert_eq!(
+        root_hash,
+        Felt::from_hex("0x032C61E78534A30DD005DB4B9136AA64893CC2F6E10C4535DD6F29BFB2ADC726")
+            .unwrap()
+    );
+}
+
+#[test]
+fn test_block_7_starknet_2() {
+    let config = BonsaiStorageConfig::default();
+    let bonsai_db = HashMapDb::<BasicId>::default();
+    let mut bonsai_storage = BonsaiStorage::<_, _, Pedersen>::new(bonsai_db, config)
+        .expect("Failed to create bonsai storage");
+    let identifier = "0x421203c58e1b4a6c3675be26cfaa18d2b6b42695ca206be1f08ce29f7f1bc7c".as_bytes();
+
+    // Insert Block 5 storage changes for contract `0x421203c58e1b4a6c3675be26cfaa18d2b6b42695ca206be1f08ce29f7f1bc7c`
+    let block_5 = [
+        (
+            "0x2bb6a7dd9cbb9cec8fdad9c0557bd539683f7ea65d4f14d41fe4d72311775e3",
+            "0x7c7",
+        ),
+        (
+            "0x584d53558c6731da8923f60f2d182027312ffa4e811e7eddc6401232d33400e",
+            "0x29bc2bad472c81f00b7873d7d27a68d63dc9ebd3a3661e2b4c3d6c90d732454",
+        ),
+        (
+            "0x6c27ff92eab8802ca5141a60a5699e5075725d5526752c5fb368c12582af00c",
+            "0x645a108cc9b963369b91cad8a8b5c2ce774b79e871368d301d518012925abc6",
+        ),
+        ("0x5", "0x66"),
+        (
+            "0x744f7d93c67c2ac6fbcdf632d530cebdbffa112d0cfacce28ed5773babfba60",
+            "0x2a49283d206395239d0c1d505a8ba2f446419e58a1fd40caccf796e810759d5",
+        ),
+        (
+            "0x11f391c712bb4996774106b93766bc49f8bdb29b416cae0da0d981752c1a28b",
+            "0x43f3925b460d387343381e31e2f9299100609bc833f289bfd67316a0a06ce40",
+        ),
+        (
+            "0x11f391c712bb4996774106b93766bc49f8bdb29b416cae0da0d981752c1a28c",
+            "0x2b72713e2fc2dec7cfe8e7c428f02728a031f17f876bb50841d4ee3eb12834",
+        ),
+        (
+            "0x66631ce6af4e11972e05bed46e9b20a5480ffea4ae2a4d95e1d71fb37f25c0",
+            "0x1329ffd6765c348b5e7195b777241cf5eb84e438c0f5fa3acb5800ada846332",
+        ),
+    ];
+
+    for (key_hex, value_hex) in block_5.iter() {
+        let key = Felt::from_hex(key_hex).unwrap();
+        let value = Felt::from_hex(value_hex).unwrap();
+        bonsai_storage
+            .insert(identifier, keyer(key).as_bitslice(), &value)
+            .expect("Failed to insert storage update into trie");
+    }
+
+    let mut id_builder = BasicIdBuilder::new();
+    let id = id_builder.new_id();
+    bonsai_storage
+        .commit(id)
+        .expect("Failed to commit to bonsai storage");
+    let root_hash = bonsai_storage
+        .root_hash(identifier)
+        .expect("Failed to get root hash");
+
+    println!("Expected: 0x03846F4AE281ADBCC68518766579DB77C27EF31955E9FC3183C397C2731A7627\nFound: {root_hash:#x}");
+    assert_eq!(
+        root_hash,
+        Felt::from_hex("0x03846F4AE281ADBCC68518766579DB77C27EF31955E9FC3183C397C2731A7627")
+            .unwrap()
+    );
+
+    // Insert Block 6 storage changes for contract `0x421203c58e1b4a6c3675be26cfaa18d2b6b42695ca206be1f08ce29f7f1bc7c`
+    let block_6 = [
+        (
+            "0x591192c633e49a7e6ca0aae77da4e9a1df2c6db51cabb3cc929280a44745635",
+            "0x1b3479bec749469312a35a2001dc8cfaf38723c0a8763e01ad2abaefb2214e5",
+        ),
+        (
+            "0x58bfc110ce09fc2bcff40dbb4887bfb32f5156f2195e8f6ea22e15784c01768",
+            "0x71cc8515287a6f5d8b81675bc7e41ca1fcd75afcc60984701033f0cdd05acd",
+        ),
+        (
+            "0x58bfc110ce09fc2bcff40dbb4887bfb32f5156f2195e8f6ea22e15784c01769",
+            "0x6a8a49d797b80ef2be0ec8a72f71dccb655c07297f95e022a26a65787c3199c",
+        ),
+    ];
+
+    for (key_hex, value_hex) in block_6.iter() {
+        let key = Felt::from_hex(key_hex).unwrap();
+        let value = Felt::from_hex(value_hex).unwrap();
+        bonsai_storage
+            .insert(identifier, keyer(key).as_bitslice(), &value)
+            .expect("Failed to insert storage update into trie");
+    }
+
+    let id = id_builder.new_id();
+    bonsai_storage
+        .commit(id)
+        .expect("Failed to commit to bonsai storage");
+    let root_hash = bonsai_storage
+        .root_hash(identifier)
+        .expect("Failed to get root hash");
+
+    println!("Expected: 0x06E02FE529D3CBDCC5324D0981F991E777DAFC3F0C24E7CB56CE3D379BE9B510\nFound: {root_hash:#x}");
+    assert_eq!(
+        root_hash,
+        Felt::from_hex("0x06E02FE529D3CBDCC5324D0981F991E777DAFC3F0C24E7CB56CE3D379BE9B510")
+            .unwrap()
+    );
+
+    // Insert Block 6 storage changes for contract `0x421203c58e1b4a6c3675be26cfaa18d2b6b42695ca206be1f08ce29f7f1bc7c`
+    let block_7 = [("0x5", "0x0")];
+
+    for (key_hex, value_hex) in block_7.iter() {
+        let key = Felt::from_hex(key_hex).unwrap();
+        let value = Felt::from_hex(value_hex).unwrap();
+        bonsai_storage
+            .insert(identifier, keyer(key).as_bitslice(), &value)
+            .expect("Failed to insert storage update into trie");
+    }
+
+    let id = id_builder.new_id();
+    bonsai_storage
+        .commit(id)
+        .expect("Failed to commit to bonsai storage");
+    let root_hash = bonsai_storage
+        .root_hash(identifier)
+        .expect("Failed to get root hash");
+
+    println!("Expected: 0x0528E360EA90E94F670451A76A7698900F0F7C1F2E88583F8B0162D486BF7947\nFound: {root_hash:#x}");
+    assert_eq!(
+        root_hash,
+        Felt::from_hex("0x0528E360EA90E94F670451A76A7698900F0F7C1F2E88583F8B0162D486BF7947")
+            .unwrap()
+    )
+}
+
+#[test]
+fn test_block_9() {
+    let config = BonsaiStorageConfig::default();
+    let bonsai_db = HashMapDb::<BasicId>::default();
+    let mut bonsai_storage = BonsaiStorage::<_, _, Pedersen>::new(bonsai_db, config)
+        .expect("Failed to create bonsai storage");
+    let identifier =
+        "0x06F3C934BA4EC49245CB9A42FC715E4D589AA502AF69BE13916127A538D525CE".as_bytes();
+
+    // Insert Block 8 storage changes for contract `0x06F3C934BA4EC49245CB9A42FC715E4D589AA502AF69BE13916127A538D525CE`
+    let block_8 = [
+        ("0x5", "0x456"),
+        (
+            "0x4b788ad12d2e47b2be358d61cc38d813aa79165ddbc0b29d4878ef0fbc18c15",
+            "0x612af3160e28962cb3dd6146a9c2f7bd7adeea1fddd39f767d936c7b5bcca97",
+        ),
+    ];
+
+    for (key_hex, value_hex) in block_8.iter() {
+        let key = Felt::from_hex(key_hex).unwrap();
+        let value = Felt::from_hex(value_hex).unwrap();
+        bonsai_storage
+            .insert(identifier, keyer(key).as_bitslice(), &value)
+            .expect("Failed to insert storage update into trie");
+    }
+
+    let mut id_builder = BasicIdBuilder::new();
+    let id = id_builder.new_id();
+    bonsai_storage
+        .commit(id)
+        .expect("Failed to commit to bonsai storage");
+    let root_hash = bonsai_storage
+        .root_hash(identifier)
+        .expect("Failed to get root hash");
+
+    println!("Expected: 0x010AA5D1D36847AE64BA074B3A878BFD1A9AEAA952F6777C727EEA6AE6B2C99F\nFound: {root_hash:#x}");
+    assert_eq!(
+        root_hash,
+        Felt::from_hex("0x010AA5D1D36847AE64BA074B3A878BFD1A9AEAA952F6777C727EEA6AE6B2C99F")
+            .unwrap()
+    );
+
+    // Insert Block 9 storage changes for contract `0x06F3C934BA4EC49245CB9A42FC715E4D589AA502AF69BE13916127A538D525CE`
+    let block_9 = [("0x5", "0x0")];
+
+    for (key_hex, value_hex) in block_9.iter() {
+        let key = Felt::from_hex(key_hex).unwrap();
+        let value = Felt::from_hex(value_hex).unwrap();
+        bonsai_storage
+            .insert(identifier, keyer(key).as_bitslice(), &value)
+            .expect("Failed to insert storage update into trie");
+    }
+
+    let id = id_builder.new_id();
+    bonsai_storage
+        .commit(id)
+        .expect("Failed to commit to bonsai storage");
+    let root_hash = bonsai_storage
+        .root_hash(identifier)
+        .expect("Failed to get root hash");
+
+    println!("Expected: 0x00072F7E2EC1A2F05342503B49AECD83E14884AE374A8570F2F6F7B868CF94AE\nFound: {root_hash:#x}");
+    assert_eq!(
+        root_hash,
+        Felt::from_hex("0x00072F7E2EC1A2F05342503B49AECD83E14884AE374A8570F2F6F7B868CF94AE")
+            .unwrap()
     );
 }

--- a/src/trie/merkle_tree.rs
+++ b/src/trie/merkle_tree.rs
@@ -71,6 +71,7 @@ pub(crate) struct MerkleTrees<H: StarkHash + Send + Sync, DB: BonsaiDatabase, Co
     pub trees: HashMap<Vec<u8>, MerkleTree<H>>,
 }
 
+#[cfg(feature = "bench")]
 impl<H: StarkHash + Send + Sync, DB: BonsaiDatabase + Clone, CommitID: Id> Clone
     for MerkleTrees<H, DB, CommitID>
 {
@@ -268,6 +269,7 @@ pub struct MerkleTree<H: StarkHash> {
 }
 
 // NB: #[derive(Clone)] does not work because it expands to an impl block which forces H: Clone, which Pedersen/Poseidon aren't.
+#[cfg(feature = "bench")]
 impl<H: StarkHash> Clone for MerkleTree<H> {
     fn clone(&self) -> Self {
         Self {

--- a/src/trie/merkle_tree.rs
+++ b/src/trie/merkle_tree.rs
@@ -1,5 +1,5 @@
 #[cfg(not(feature = "std"))]
-use alloc::{format, string::ToString, vec::Vec, vec};
+use alloc::{format, string::ToString, vec, vec::Vec};
 use bitvec::{
     prelude::{BitSlice, BitVec, Msb0},
     view::BitView,

--- a/src/trie/merkle_tree.rs
+++ b/src/trie/merkle_tree.rs
@@ -1,5 +1,5 @@
 #[cfg(not(feature = "std"))]
-use alloc::{format, string::ToString, vec::Vec};
+use alloc::{format, string::ToString, vec::Vec, vec};
 use bitvec::{
     prelude::{BitSlice, BitVec, Msb0},
     view::BitView,
@@ -395,13 +395,13 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
         node_handle: &NodeHandle,
     ) -> Result<NodeOrFelt, BonsaiStorageError<DB::DatabaseError>> {
         let node_id = match node_handle {
-            NodeHandle::Hash(hash) => return Ok(NodeOrFelt::Felt(hash.clone())),
+            NodeHandle::Hash(hash) => return Ok(NodeOrFelt::Felt(*hash)),
             NodeHandle::InMemory(root_id) => root_id,
         };
         let node = self
             .storage_nodes
             .0
-            .get(&node_id)
+            .get(node_id)
             .ok_or(BonsaiStorageError::Trie(
                 "Couldn't fetch node in the temporary storage".to_string(),
             ))?;
@@ -427,7 +427,7 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
         use Node::*;
 
         match node {
-            Unresolved(hash) => Ok(hash.clone()),
+            Unresolved(hash) => Ok(*hash),
             Binary(binary) => {
                 // we check if we have one or two changed children
 

--- a/src/trie/mod.rs
+++ b/src/trie/mod.rs
@@ -3,4 +3,4 @@ pub mod merkle_tree;
 mod path;
 mod trie_db;
 
-pub use trie_db::TrieKey;
+pub(crate) use trie_db::TrieKey;

--- a/src/trie/path.rs
+++ b/src/trie/path.rs
@@ -1,7 +1,7 @@
 use bitvec::{order::Msb0, vec::BitVec};
 use parity_scale_codec::{Decode, Encode, Error, Input, Output};
 
-use super::{merkle_node::Direction, TrieKey};
+use super::merkle_node::Direction;
 
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
@@ -104,25 +104,26 @@ impl Path {
     }
 }
 
-impl From<Path> for TrieKey {
+/// Convert Path to Vec<u8> can be used, for example, to create keys for the database
+impl From<Path> for Vec<u8> {
     fn from(path: Path) -> Self {
         let key = if path.0.is_empty() {
             Vec::new()
         } else {
             [&[path.0.len() as u8], path.0.as_raw_slice()].concat()
         };
-        TrieKey::Trie(key)
+        key
     }
 }
 
-impl From<&Path> for TrieKey {
+impl From<&Path> for Vec<u8> {
     fn from(path: &Path) -> Self {
         let key = if path.0.is_empty() {
             Vec::new()
         } else {
             [&[path.0.len() as u8], path.0.as_raw_slice()].concat()
         };
-        TrieKey::Trie(key)
+        key
     }
 }
 

--- a/src/trie/trie_db.rs
+++ b/src/trie/trie_db.rs
@@ -4,13 +4,14 @@ use crate::bonsai_database::DatabaseKey;
 use alloc::vec::Vec;
 
 /// Key in the database of the different elements that are used in the storage of the trie data.
+/// Use `new` function to create a new key.
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
-pub enum TrieKey {
+pub(crate) enum TrieKey {
     Trie(Vec<u8>),
     Flat(Vec<u8>),
 }
 
-enum TrieKeyType {
+pub(crate) enum TrieKeyType {
     Trie = 0,
     Flat = 1,
 }
@@ -34,6 +35,15 @@ impl From<&TrieKey> for u8 {
 }
 
 impl TrieKey {
+    pub fn new(identifier: &[u8], key_type: TrieKeyType, key: &[u8]) -> Self {
+        let mut final_key = identifier.to_vec();
+        final_key.extend_from_slice(key);
+        match key_type {
+            TrieKeyType::Trie => TrieKey::Trie(final_key),
+            TrieKeyType::Flat => TrieKey::Flat(final_key),
+        }
+    }
+
     pub fn from_variant_and_bytes(variant: u8, bytes: Vec<u8>) -> Self {
         match variant {
             x if x == TrieKeyType::Trie as u8 => TrieKey::Trie(bytes),


### PR DESCRIPTION
Hello, this PR is on top of `add_multi_trie_management` for now.

During the commit of a MerkleTree, when we encounter a Binary node, we can compute the hash of both of the edges in parallel.
Hash computation and committing have been separated, the former one being `rayon`ized and pushing to a vec, which the latter one consumes

Feel free to ask questions around the `rayon::join` part, it's a low level rayon primitive made for this kind of case but it can be a bit obscure 

@AurelienFT 